### PR TITLE
[fix-cve-0.2]: Update go.mod dependencies [SECURITY]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/upbound/provider-opentofu
 
-go 1.23.6
+go 1.23.10
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0


### PR DESCRIPTION
Updates go mod dependencies to fix the following CVE:

CVE-2025-22874